### PR TITLE
Widen `psr/container` requirement to include `v1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "psr/container": "^2.0",
+        "psr/container": "^1.1.2 || ^2.0",
         "sanmai/pipeline": "^6.17 || ^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
A recent (good) change in Infection https://github.com/infection/infection/pull/2343 halted me from upgrading it, and I have no control over when the DI implementation I'm using will update itself to be `psr/container:v2` compatible.

But since any `v2` implementation is also `v1` compatible, I'm asking you to widen this package requirement to include it.