### PR TITLE
Allow set()/bind() to accept a plain implementation class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,20 @@ $container = new Container([
     ),
     DatabaseInterface::class => fn(Container $container) =>
         $container->get(DatabaseBuilder::class)->build(),
+    // Concrete class names also work when suggesting a preferred implementation
+    CommonAbstractClass::class => ConcreteImplementation::class,
 ]);
 
 // Set additional dependencies on the fly
 $container->set(LoggerInterface::class, fn() => new FileLogger('debug.log'));
+$container->set(SomeInterface::class, PreferredImplementation::class);
 
 $service = $container->get(ServiceNeedingDatabase::class); // Auto-injects database
 ```
 
 The order in which you define your services is not important, as dependencies are only resolved when they are requested.
 
-That said, injected pre-built instance instances override prior dependencies for that ID, but a later `set()` or `bind()` overrides again.
+That said, injected pre-built instances override prior dependencies for that ID, but a later `set()` or `bind()` overrides again.
 
 ## Builder Objects
 
@@ -92,7 +95,7 @@ $container = new Container([
 ]);
 ```
 
-For setting dependencies on the fly, there's a handy `set()` method that accepts both callables and builders.
+For setting dependencies on the fly, there's a handy `set()` method that accepts callables, builder class names, and implementation class names. Callables have a priority over builders.
 
 ## Non-Class Service IDs
 
@@ -119,7 +122,7 @@ $container->bind('app.session', SessionBuilder::class);
 $repository = $container->get('app.repository');
 ```
 
-The `bind()` method and `$bindings` parameter accept both callables and builder class names, just like `set()`, but without class-string type constraints on the service ID.
+The `bind()` method and `$bindings` parameter accept callables, builder class names, and implementation class names, just like `set()`, but without class-string type constraints on the service ID.
 
 ## Pre-Built Instances
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -209,7 +209,7 @@ class Container implements ContainerInterface
         }
 
         // Resolve concrete implementations using common rules
-        if (array_key_exists($id, $this->implementations)) {
+        if (array_key_exists($id, $this->implementations) && $this->implementations[$id] !== $id) {
             return $this->setValueOrThrow($id, $this->get($this->implementations[$id]));
         }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -209,7 +209,10 @@ class Container implements ContainerInterface
         }
 
         // Resolve concrete implementations using common rules
-        if (array_key_exists($id, $this->implementations) && $this->implementations[$id] !== $id) {
+        if (
+            array_key_exists($id, $this->implementations)
+            && $this->implementations[$id] !== $id
+        ) {
             return $this->setValueOrThrow($id, $this->get($this->implementations[$id]));
         }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -77,12 +77,17 @@ class Container implements ContainerInterface
      */
     private array $builders = [];
 
+    /**
+     * @var array<class-string<object>|non-empty-string, class-string<object>>
+     */
+    private array $implementations = [];
+
     /** Placeholder marking an unresolved parameter */
     private readonly object $missing;
 
     /**
-     * @param iterable<class-string<object>, callable|class-string<Builder<object>>> $values
-     * @param iterable<non-empty-string, callable|class-string<Builder<object>>> $bindings
+     * @param iterable<class-string<object>, callable|class-string<Builder<object>>|class-string<object>> $values
+     * @param iterable<non-empty-string, callable|class-string<Builder<object>>|class-string<object>> $bindings For non-class service IDs
      */
     public function __construct(iterable $values = [], iterable $bindings = [])
     {
@@ -101,11 +106,11 @@ class Container implements ContainerInterface
     }
 
     /**
-     * Register a factory or builder for a class-based service ID.
+     * Register a factory, a builder, or an implementation class for a class-based service ID.
      *
      * @template T of object
      * @param class-string<T> $id
-     * @param class-string<Builder<T>>|callable(static): T $value
+     * @param class-string<T>|class-string<Builder<T>>|callable(static): T $value
      */
     public function set(string $id, callable|string $value): void
     {
@@ -113,15 +118,15 @@ class Container implements ContainerInterface
     }
 
     /**
-     * Register a factory or builder for a non-class service ID (e.g., 'app.locator').
+     * Register a factory, a builder, or an implementation class for a non-class service ID (e.g., 'app.locator').
      *
      * @param non-empty-string $id
-     * @param class-string<Builder<object>>|callable(static): object $value
+     * @param class-string<object>|class-string<Builder<object>>|callable(static): object $value
      */
     public function bind(string $id, callable|string $value): void
     {
         // Registered dependencies override everything else at bind time
-        unset($this->values[$id], $this->factories[$id], $this->builders[$id], $this->prebuilt[$id]);
+        unset($this->values[$id], $this->factories[$id], $this->builders[$id], $this->implementations[$id], $this->prebuilt[$id]);
 
         // A value can be a callable and also implement our `Builder` interface:
         // we must treat such cases as factories, not builders, to ensure
@@ -131,7 +136,12 @@ class Container implements ContainerInterface
             return;
         }
 
-        $this->builders[$id] = $value;
+        if (is_a($value, Builder::class, true)) {
+            $this->builders[$id] = $value;
+            return;
+        }
+
+        $this->implementations[$id] = $value;
     }
 
     /**
@@ -144,7 +154,7 @@ class Container implements ContainerInterface
     public function inject(string $id, object $value): void
     {
         // Injected pre-built dependencies override everything else at the time of injection
-        unset($this->values[$id], $this->factories[$id], $this->builders[$id]);
+        unset($this->values[$id], $this->factories[$id], $this->builders[$id], $this->implementations[$id]);
 
         self::assertType($id, $value);
 
@@ -196,6 +206,11 @@ class Container implements ContainerInterface
 
         if (array_key_exists($id, $this->prebuilt)) {
             return $this->prebuilt[$id];
+        }
+
+        // Resolve concrete implementations using common rules
+        if (array_key_exists($id, $this->implementations)) {
+            return $this->setValueOrThrow($id, $this->get($this->implementations[$id]));
         }
 
         // Builders and factories assume extra work, so they follow next
@@ -324,7 +339,7 @@ class Container implements ContainerInterface
     }
 
     /**
-     * Retrieves the class or interface names of all registered factories/builders that can produce instances of the given type.
+     * Retrieves the class or interface names of all registered factories/builders/etc that can produce instances of the given type.
      * This includes direct implementations, subclasses, or the type itself.
      *
      * @template T of object
@@ -334,7 +349,7 @@ class Container implements ContainerInterface
     private function providersForType(string $type): array
     {
         /** @var list<class-string<object>> */
-        return take($this->factories, $this->builders, $this->prebuilt)
+        return take($this->factories, $this->builders, $this->implementations, $this->prebuilt)
             ->keys()
             ->filter(static fn(string $id) => is_a($id, $type, true))
             ->toList();
@@ -343,6 +358,10 @@ class Container implements ContainerInterface
     public function has(string $id): bool
     {
         if (array_key_exists($id, $this->values)) {
+            return true;
+        }
+
+        if (array_key_exists($id, $this->implementations)) {
             return true;
         }
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -257,11 +257,8 @@ class ContainerTest extends TestCase
     public function testItUnderstandsImplementationClassNames(): void
     {
         $container = new Container([
-            SimpleObject::class => SimpleObject::class,
             NamedObjectInterface::class => NameProvider::class,
         ]);
-
-        $this->assertInstanceOf(SimpleObject::class, $container->get(SimpleObject::class));
 
         $this->assertTrue($container->has(NamedObjectInterface::class));
 
@@ -273,6 +270,10 @@ class ContainerTest extends TestCase
         $this->assertSame($object, $container->get(NameProvider::class));
 
         $this->assertSame('hello', $container->get(NameNeeder::class)->getName());
+
+        $container->set(SimpleObject::class, SimpleObject::class);
+
+        $this->assertInstanceOf(SimpleObject::class, $container->get(SimpleObject::class));
     }
 
     public function testItThrowsOnSelfReferencingInterfaces(): void

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -254,6 +254,24 @@ class ContainerTest extends TestCase
         $this->assertSame('hello', $nameNeeder->getName());
     }
 
+    public function testItUnderstandsImplementationClassNames(): void
+    {
+        $container = new Container([
+            NamedObjectInterface::class => NameProvider::class,
+        ]);
+
+        $this->assertTrue($container->has(NamedObjectInterface::class));
+
+        $object = $container->get(NamedObjectInterface::class);
+
+        $this->assertInstanceOf(NameProvider::class, $object);
+        $this->assertSame('hello', $object->getName());
+
+        $this->assertSame($object, $container->get(NameProvider::class));
+
+        $this->assertSame('hello', $container->get(NameNeeder::class)->getName());
+    }
+
     public function testItHas(): void
     {
         $container = new Container([

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -257,8 +257,11 @@ class ContainerTest extends TestCase
     public function testItUnderstandsImplementationClassNames(): void
     {
         $container = new Container([
+            SimpleObject::class => SimpleObject::class,
             NamedObjectInterface::class => NameProvider::class,
         ]);
+
+        $this->assertInstanceOf(SimpleObject::class, $container->get(SimpleObject::class));
 
         $this->assertTrue($container->has(NamedObjectInterface::class));
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -272,6 +272,18 @@ class ContainerTest extends TestCase
         $this->assertSame('hello', $container->get(NameNeeder::class)->getName());
     }
 
+    public function testItThrowsOnSelfReferencingInterfaces(): void
+    {
+        $container = new Container([
+            NamedObjectInterface::class => NamedObjectInterface::class,
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unknown service');
+
+        $container->get(NamedObjectInterface::class);
+    }
+
     public function testItHas(): void
     {
         $container = new Container([


### PR DESCRIPTION
A registered class name that isn't a `Builder` is now autowired directly as the service implementation, instead of requiring a factory closure or explicit `Builder` wrapper.