### PR TITLE
Re-binding overrides factories and builders

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -120,7 +120,7 @@ class Container implements ContainerInterface
      */
     public function bind(string $id, callable|string $value): void
     {
-        // The latest registration overrides every prior one
+        // Registered dependencies override everything else at bind time
         unset($this->values[$id], $this->factories[$id], $this->builders[$id]);
 
         // A value can be a callable and also implement our `Builder` interface:

--- a/src/Container.php
+++ b/src/Container.php
@@ -120,7 +120,8 @@ class Container implements ContainerInterface
      */
     public function bind(string $id, callable|string $value): void
     {
-        unset($this->values[$id]);
+        // The latest registration overrides every prior one
+        unset($this->values[$id], $this->factories[$id], $this->builders[$id]);
 
         // A value can be a callable and also implement our `Builder` interface:
         // we must treat such cases as factories, not builders, to ensure

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -237,6 +237,18 @@ class ContainerTest extends TestCase
         $this->assertSame('hello', $nameNeeder->getName());
     }
 
+    public function testBindReplacesPriorBuilder(): void
+    {
+        $container = new Container([
+            NamedObjectInterface::class => ComplexObjectBuilder::class,
+        ]);
+
+        $container->set(NamedObjectInterface::class, static fn() => new NameProvider());
+
+        // The builder must leave no trace behind
+        $this->assertInstanceOf(NameProvider::class, $container->get(NamedObjectInterface::class));
+    }
+
     public function testItHas(): void
     {
         $container = new Container([

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -245,8 +245,8 @@ class ContainerTest extends TestCase
 
         $container->set(NamedObjectInterface::class, static fn() => new NameProvider());
 
-        // The builder must leave no trace behind
         $this->assertInstanceOf(NameProvider::class, $container->get(NamedObjectInterface::class));
+        $this->assertNotInstanceOf(ComplexObject::class, $container->get(NamedObjectInterface::class));
     }
 
     public function testItHas(): void

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -237,17 +237,6 @@ class ContainerTest extends TestCase
         $this->assertSame('hello', $nameNeeder->getName());
     }
 
-    public function testBindReplacesPriorBuilder(): void
-    {
-        $container = new Container([
-            NamedObjectInterface::class => ComplexObjectBuilder::class,
-        ]);
-
-        $container->set(NamedObjectInterface::class, static fn() => new NameProvider());
-
-        $this->assertInstanceOf(NameProvider::class, $container->get(NamedObjectInterface::class));
-        $this->assertNotInstanceOf(ComplexObject::class, $container->get(NamedObjectInterface::class));
-    }
 
     public function testItHas(): void
     {
@@ -458,6 +447,22 @@ class ContainerTest extends TestCase
 
         $this->assertSame($rebound, $container->get(SimpleObject::class));
         $this->assertNotSame($injected, $container->get(SimpleObject::class));
+    }
+
+    public function testBindOverridesBuilder(): void
+    {
+        $container = new Container();
+        $container->set(NamedObjectInterface::class, ComplexObjectBuilder::class);
+        $built = $container->get(SimpleObject::class);
+
+        $bound = new NameProvider();
+        $container->set(NamedObjectInterface::class, static fn() => $bound);
+
+        $this->assertInstanceOf(NameProvider::class, $container->get(NamedObjectInterface::class));
+        $this->assertNotInstanceOf(ComplexObject::class, $container->get(NamedObjectInterface::class));
+
+        $this->assertNotSame($built, $container->get(NamedObjectInterface::class));
+        $this->assertSame($bound, $container->get(NamedObjectInterface::class));
     }
 
     public function testInjectSingletonBehavior(): void

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -453,16 +453,16 @@ class ContainerTest extends TestCase
     {
         $container = new Container();
         $container->set(NamedObjectInterface::class, ComplexObjectBuilder::class);
-        $built = $container->get(SimpleObject::class);
+        $built = $container->get(NamedObjectInterface::class);
 
         $bound = new NameProvider();
         $container->set(NamedObjectInterface::class, static fn() => $bound);
 
-        $this->assertInstanceOf(NameProvider::class, $container->get(NamedObjectInterface::class));
-        $this->assertNotInstanceOf(ComplexObject::class, $container->get(NamedObjectInterface::class));
-
         $this->assertNotSame($built, $container->get(NamedObjectInterface::class));
         $this->assertSame($bound, $container->get(NamedObjectInterface::class));
+
+        $this->assertInstanceOf(NameProvider::class, $container->get(NamedObjectInterface::class));
+        $this->assertNotInstanceOf(ComplexObject::class, $container->get(NamedObjectInterface::class));
     }
 
     public function testInjectSingletonBehavior(): void

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -237,7 +237,6 @@ class ContainerTest extends TestCase
         $this->assertSame('hello', $nameNeeder->getName());
     }
 
-
     public function testItHas(): void
     {
         $container = new Container([


### PR DESCRIPTION
A rebind previously only unset the cached value, leaving stale factory/builder entries able to shadow the new registration.