### PR TITLE
Clear prebuilt instances when bind() overrides a service

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -121,7 +121,7 @@ class Container implements ContainerInterface
     public function bind(string $id, callable|string $value): void
     {
         // Registered dependencies override everything else at bind time
-        unset($this->values[$id], $this->factories[$id], $this->builders[$id]);
+        unset($this->values[$id], $this->factories[$id], $this->builders[$id], $this->prebuilt[$id]);
 
         // A value can be a callable and also implement our `Builder` interface:
         // we must treat such cases as factories, not builders, to ensure
@@ -189,10 +189,16 @@ class Container implements ContainerInterface
      */
     public function get(string $id)
     {
+        // All kinds of already built instances come first
         if (array_key_exists($id, $this->values)) {
             return $this->values[$id];
         }
 
+        if (array_key_exists($id, $this->prebuilt)) {
+            return $this->prebuilt[$id];
+        }
+
+        // Builders and factories assume extra work, so they follow next
         if (array_key_exists($id, $this->builders)) {
             /** @var Builder<T> $builder */
             $builder = $this->get($this->builders[$id]);
@@ -205,11 +211,6 @@ class Container implements ContainerInterface
             $value = $this->factories[$id]($this);
 
             return $this->setValueOrThrow($id, $value);
-        }
-
-        // Consider pre-built instances last to give way to factories and builders
-        if (array_key_exists($id, $this->prebuilt)) {
-            return $this->prebuilt[$id];
         }
 
         $value = $this->createService($id);

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -463,6 +463,8 @@ class ContainerTest extends TestCase
 
         $this->assertSame($rebound, $container->get(SimpleObject::class));
         $this->assertNotSame($injected, $container->get(SimpleObject::class));
+
+        $this->assertSame($rebound, $container->get(DependentObject::class)->getSimpleObject());
     }
 
     public function testBindOverridesBuilder(): void


### PR DESCRIPTION
`bind()` used to reset values, factories, builders, but left stale prebuilt instances in place, letting them resurface via `get()` after a service was rebound.