### PR TITLE
Detect circular implementation mappings in bind()/set()

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -141,7 +141,26 @@ class Container implements ContainerInterface
             return;
         }
 
+        $this->assertNoImplementationCycle($id, $value);
         $this->implementations[$id] = $value;
+    }
+
+    private function assertNoImplementationCycle(string $id, string $implementation): void
+    {
+        while (array_key_exists($implementation, $this->implementations)) {
+            $nextImplementation = $this->implementations[$implementation];
+
+            // Existing self-maps terminate the implementation chain.
+            if ($nextImplementation === $implementation) {
+                return;
+            }
+
+            if ($nextImplementation === $id) {
+                throw new Exception(sprintf('Circular implementation mapping involving "%s"', $id));
+            }
+
+            $implementation = $nextImplementation;
+        }
     }
 
     /**

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -288,6 +288,29 @@ class ContainerTest extends TestCase
         $container->get(NamedObjectInterface::class);
     }
 
+    public function testItRejectsCircularImplementationMappings(): void
+    {
+        $container = new Container();
+        $container->bind(SimpleObject::class, NameProvider::class);
+        $container->bind(NameProvider::class, DependentObject::class);
+        $container->bind(NamedObjectInterface::class, SimpleObject::class);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Circular implementation mapping');
+
+        $container->bind(DependentObject::class, SimpleObject::class);
+    }
+
+    public function testItAcceptsMappingsToSelfMappedConcreteClasses(): void
+    {
+        $container = new Container([
+            SimpleObject::class => SimpleObject::class,
+        ]);
+        $container->bind('app.simple', SimpleObject::class);
+
+        $this->assertInstanceOf(SimpleObject::class, $container->get('app.simple'));
+    }
+
     public function testItHas(): void
     {
         $container = new Container([


### PR DESCRIPTION
Chained class-name mappings (A -> B -> A) previously autowired successfully, silently ignoring the cycle. bind()/set() now walk the implementation chain and throw when a mapping would loop back to the original id, while self-mapped concrete classes remain valid endpoints.