### PR TITLE
Require sanmai/pipeline ^7.10, drop 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=8.2",
         "psr/container": "^1.1.2 || ^2.0",
-        "sanmai/pipeline": "^6.17 || ^7.0"
+        "sanmai/pipeline": "^7.10"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.8",


### PR DESCRIPTION
The library relies on pipeline features (`->select()`) not present in 6.x.