### PR TITLE
Update the type check in inject() to preserve container's state

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -153,10 +153,10 @@ class Container implements ContainerInterface
      */
     public function inject(string $id, object $value): void
     {
+        self::assertType($id, $value);
+
         // Injected pre-built dependencies override everything else at the time of injection
         unset($this->values[$id], $this->factories[$id], $this->builders[$id], $this->implementations[$id]);
-
-        self::assertType($id, $value);
 
         $this->prebuilt[$id] = $value;
     }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -465,13 +465,13 @@ class ContainerTest extends TestCase
 
     public function testFailedInjectKeepsPriorRegistration(): void
     {
-        $bound = new SimpleObject();
+        $canary = new SimpleObject();
 
         $container = new Container([
-            SimpleObject::class => static fn() => $bound,
+            SimpleObject::class => static fn() => $canary,
         ]);
 
-        $this->assertSame($bound, $container->get(SimpleObject::class));
+        $this->assertSame($canary, $container->get(SimpleObject::class));
 
         try {
             $container->inject(SimpleObject::class, new NameProvider());
@@ -481,7 +481,7 @@ class ContainerTest extends TestCase
         }
 
         $this->assertTrue($container->has(SimpleObject::class));
-        $this->assertSame($bound, $container->get(SimpleObject::class));
+        $this->assertSame($canary, $container->get(SimpleObject::class));
     }
 
     public function testInjectOverridesBind(): void

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -463,6 +463,25 @@ class ContainerTest extends TestCase
         $container->inject(DependentObject::class, new SimpleObject());
     }
 
+    public function testFailedInjectKeepsPriorRegistration(): void
+    {
+        $container = new Container();
+        $bound = new SimpleObject();
+        $container->bind(SimpleObject::class, static fn() => $bound);
+
+        $this->assertSame($bound, $container->get(SimpleObject::class));
+
+        try {
+            $container->inject(SimpleObject::class, new NameProvider());
+            $this->fail('Expected a type mismatch exception');
+        } catch (Exception $exception) {
+            $this->assertStringContainsString('Expected instance of', $exception->getMessage());
+        }
+
+        $this->assertTrue($container->has(SimpleObject::class));
+        $this->assertSame($bound, $container->get(SimpleObject::class));
+    }
+
     public function testInjectOverridesBind(): void
     {
         $container = new Container();

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -465,9 +465,11 @@ class ContainerTest extends TestCase
 
     public function testFailedInjectKeepsPriorRegistration(): void
     {
-        $container = new Container();
         $bound = new SimpleObject();
-        $container->bind(SimpleObject::class, static fn() => $bound);
+
+        $container = new Container([
+            SimpleObject::class => static fn() => $bound,
+        ]);
 
         $this->assertSame($bound, $container->get(SimpleObject::class));
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -463,7 +463,7 @@ class ContainerTest extends TestCase
         $container->inject(DependentObject::class, new SimpleObject());
     }
 
-    public function testFailedInjectKeepsPriorRegistration(): void
+    public function testInjectKeepsPriorRegistration(): void
     {
         $canary = new SimpleObject();
 


### PR DESCRIPTION
A failed type check previously still unset the existing provider for the ID, potentially leaving the container without a usable registration even though `inject()` failed.